### PR TITLE
complete benchmarks/nquees/ocaml/delim_nondet.ml

### DIFF
--- a/benchmarks/nqueens/ocaml/delim_nondet.ml
+++ b/benchmarks/nqueens/ocaml/delim_nondet.ml
@@ -1,6 +1,110 @@
+type 'b fcont = {k : 'c. ('b -> 'c) -> 'c}
+
+let runf f x k = (f x).k k
+
+module type MONAD = sig
+    type 'a m
+    val return : 'a -> 'a m
+
+    val bind : 'a m -> ('a -> ('b m) fcont) -> ('b m -> 'c) -> 'c
+end
 
 
-  
+module type UNIVERSAL = sig
+  type u
+  val to_u : 'a -> u
+  val from_u : u -> 'a
+end
+
+
+module Universal : UNIVERSAL = struct
+  type u = U1 | U2 of int
+  let to_u = Obj.magic
+  let from_u = Obj.magic
+end
+
+let f_to_u f x = Universal.to_u (f (Universal.from_u x))
+let f_from_u f x = Universal.from_u (f (Universal.to_u x))
+
+module type RMONAD = sig
+  module M : MONAD
+  open M
+  type ans
+
+  val reflect : 'a m -> 'a
+  val reify : (unit -> ans) -> ans m
+end
+
+module Represent (A : sig module M : MONAD;; type ans end) : (RMONAD with module M = A.M and type ans = A.ans) = struct
+  type ans = A.ans
+  module M = A.M
+
+  open A
+  open M
+
+  type stack = Universal.u list
+
+  exception Throw of stack
+  exception Done of Universal.u
+
+  let pos = ref 0
+  let len = ref 0
+
+  let (stack : stack ref) = ref []
+  let (cont : (Universal.u -> Universal.u) ref) = ref (fun x -> raise (Done x))
+
+  let reflect m =
+    if !pos < !len then
+      (pos := !pos + 1;
+       Universal.from_u (List.nth (!stack) (!len - !pos)))
+    else
+      let st = !stack in
+      bind m
+        (fun x -> {k = fun k -> cont := f_to_u k;
+                                raise (Throw ((Universal.to_u x) :: st))})
+        (f_from_u (!cont))
+
+  let rec reify_helper f =
+    try
+      (f_from_u (!cont)) (return (f ()))
+    with
+    | (Throw st) ->
+        pos := 0;
+        len := List.length st;
+        stack := st;
+        reify_helper f
+
+    | (Done x) -> Universal.from_u x
+
+
+  let reify f =
+    cont := (fun x -> raise (Done x));
+    stack := [];
+    reify_helper f
+end
+
+
+
+module ListMonad : (MONAD with type 'a m = 'a list) = struct
+  type 'a m = 'a list
+
+  let return x = [x]
+
+  let rec bind l f k = match l with
+    []      -> k []
+  | (x::xs) -> runf f x (fun a -> bind xs f
+                                    (fun b -> k (a @ b)))
+end
+
+module N = Represent(struct
+  module M = ListMonad
+  type ans = int list
+end)
+
+let choose xs = N.reflect xs
+let fail () = N.reflect []
+let withNondeterminism f = N.reify f
+
 let rec range ?(start=0) len =
     if start >= len
     then []
@@ -9,7 +113,7 @@ let rec range ?(start=0) len =
 let rec okay i c = function
   | [] -> true
   | x::xs -> c <> x && (c-x) <> i && (c-x) <> -i && okay (i+1) c xs
-                   
+
 let rec enum_nqueens n i l =
   if i == n then
     l
@@ -25,4 +129,4 @@ let rec enum_nqueens n i l =
 
 
 let n = int_of_string (Array.get Sys.argv 1) in
-print_int (List.length (withNondeterminism (fun () ->enum_nqueens n 0 [])))
+print_int (List.length (withNondeterminism (fun () -> enum_nqueens n 0 [])))

--- a/benchmarks/nqueens/ocaml/replay_nondet.ml
+++ b/benchmarks/nqueens/ocaml/replay_nondet.ml
@@ -10,13 +10,15 @@ let rec decr = function
   | (n::ns) -> (n-1)::ns
   | []      -> []
 
-let rec withNondeterminism f =
-  let v = try [f()] with Empty -> [] in
-  br_idx := decr (!br_idx);
-  pos := length (!br_idx);
-  match !br_idx with
-    [] -> v
-  |  _  -> v @ withNondeterminism f
+let withNondeterminism f =
+  let rec loop acc f =
+    let v = try [f()] with Empty -> [] in
+    br_idx := decr (!br_idx);
+    pos := length (!br_idx);
+    match !br_idx with
+    | [] -> List.rev acc
+    |  _  -> loop (List.rev_append v acc) f
+  in loop [] f
 
 let choose = function
   | [] -> raise Empty


### PR DESCRIPTION
This implementation does not seem to suffer from Stack Overflow issues (once completed with the code from `ocaml/generic_constant_stack.ml`).

Rough numbers (the `replay_nondet` measure is invalid of course, as it overflows):

```
$ ocamlbuild direct.native replay_nondet.native delim_nondet.native
$ time ./delim_nondet.native 12
14200
real	0m6.724s
user	0m6.683s
sys	0m0.013s
$ time ./direct.native 12
14200
real	0m0.265s
user	0m0.259s
sys	0m0.005s
$ time ./replay_nondet.native 12
Fatal error: exception Stack_overflow

real	0m0.708s
user	0m0.694s
sys	0m0.011s
```