### PR TITLE
add a Prolog solution (tested with SWI-Prolog)

### DIFF
--- a/benchmarks/nqueens/native.pl
+++ b/benchmarks/nqueens/native.pl
@@ -1,0 +1,28 @@
+/* solve(N, L) holds when the list L holds a valid placement for N queens */
+solve(N, L) :- queens(N, 0, [], L).
+
+/* queens(N, I, L, Res) holds when the ML function
+   (enum_nqueens N I L) would return Res. */
+queens(N, N, L, L).
+queens(N, I, L, Res) :-
+  I < N,
+  choose_in_range(0, N, C),
+  okay(1, C, L),
+  I1 is I+1,
+  queens(N, I1, [C|L], Res).
+
+/* choose_in_range(I, N, C) takes input I and N, and holds for each
+   C such that (I <= C < N); it corresponds to a combination of
+   direct-style 'choose' and 'range' in the ML version*/
+choose_in_range(I, N, I) :- I < N.
+choose_in_range(I, N, C) :- I < N, I1 is I+1, choose_in_range(I1, N, C).
+
+/* okay(I, C, L) holds when (okay I C L) is true in the ML version */
+okay(_, _, []).
+okay(I, C, [X|XS]) :- C =\= X, (C-X) =\= I, (X-C) =\= I, I1 is I+1, okay(I1, C, XS).
+
+/* aggregate_all(count, Q, Y) holds when Y is the
+   number of solutions of Q.
+   count(N, Count) holds when Count is the number of
+   valid placements of N queens. */
+count(N, Count) :- aggregate_all(count, solve(N, L), Count).

--- a/benchmarks/nqueens/prolog.sh
+++ b/benchmarks/nqueens/prolog.sh
@@ -1,0 +1,1 @@
+echo "count($1, Count)." | swipl -f native.pl


### PR DESCRIPTION
It is too hard to setup a Curry system (according to my experiments
with nqueens, KICS2 is very slow on search problems and PAKS requires
an existing Prolog setup, making it strictly harder to install than
a Prolog), so I'm adding a native Prolog version which we may use for
comparison instead.

Tested with SWI-prolog. The `prolog.sh script` gives an interface
compatible with `run_benchmark_time.rb`:

```
$ ruby ./run_benchmark_time.rb "sh prolog.sh"
sh prolog.sh
4: 89.0
5: 92.2
6: 91.4
7: 92.6
8: 115.4
9: 195.6
10: 637.4
11: 3086.8
12: 18689.4
```