### PR TITLE
Improve prolog benchmark

### DIFF
--- a/benchmarks/nqueens/collect_benchmark_data.sh
+++ b/benchmarks/nqueens/collect_benchmark_data.sh
@@ -27,9 +27,9 @@ run run_benchmark.rb      filinski_callcc.sml                     10 13 "Filinsk
 
 run run_benchmark_time.rb "./ocaml/effect.native"                 10 13 "Eff. Handlers (Multicore OCaml)"  EffOCaml
 
-run run_benchmark_time.rb "sh prolog.sh"                          8 12 "Prolog search (SWI-Prolog)"       SWIProlog
+run run_benchmark_time.rb "sh prolog.sh"                          10 12 "Prolog search (SWI-Prolog)"       SWIProlog
 
-run run_benchmark_time.rb "sh gprolog.sh"                         8 12 "Prolog search (GProlog)"          GProlog
+run run_benchmark_time.rb "sh gprolog.sh"                         10 12 "Prolog search (GProlog)"          GProlog
 
 if test "$USE_MLTON" = "true"
 then

--- a/benchmarks/nqueens/collect_benchmark_data.sh
+++ b/benchmarks/nqueens/collect_benchmark_data.sh
@@ -32,7 +32,7 @@ run run_benchmark_time.rb "./ocaml/effect.native"                 10 13 "Eff. Ha
 # profiling shows that most of the time is spent in the arithmetic comparison =/= in okay,
 # which may come from having only boxed integers.
 
-run run_benchmark_time.rb "sh gprolog.sh"                         10 13 "Prolog search (GProlog)"          Prolog
+run run_benchmark_time.rb "sh gprolog.sh"                         10 13 "Prolog search (GNU Prolog)"       Prolog
 
 if test "$USE_MLTON" = "true"
 then

--- a/benchmarks/nqueens/collect_benchmark_data.sh
+++ b/benchmarks/nqueens/collect_benchmark_data.sh
@@ -27,7 +27,9 @@ run run_benchmark.rb      filinski_callcc.sml                     10 13 "Filinsk
 
 run run_benchmark_time.rb "./ocaml/effect.native"                 10 13 "Eff. Handlers (Multicore OCaml)"  EffOCaml
 
-run run_benchmark_time.rb "sh prolog.sh"                          8 12 "Prolog search (SWI-Prolog)"       Prolog
+run run_benchmark_time.rb "sh prolog.sh"                          8 12 "Prolog search (SWI-Prolog)"       SWIProlog
+
+run run_benchmark_time.rb "sh gprolog.sh"                         8 12 "Prolog search (GProlog)"          GProlog
 
 if test "$USE_MLTON" = "true"
 then

--- a/benchmarks/nqueens/collect_benchmark_data.sh
+++ b/benchmarks/nqueens/collect_benchmark_data.sh
@@ -27,9 +27,12 @@ run run_benchmark.rb      filinski_callcc.sml                     10 13 "Filinsk
 
 run run_benchmark_time.rb "./ocaml/effect.native"                 10 13 "Eff. Handlers (Multicore OCaml)"  EffOCaml
 
-run run_benchmark_time.rb "sh prolog.sh"                          10 12 "Prolog search (SWI-Prolog)"       SWIProlog
+#run run_benchmark_time.rb "sh prolog.sh"                          10 12 "Prolog search (SWI-Prolog)"       SWIProlog
+# SWI Prolog is sensibly slower than the GNU Prolog results below, disabled
+# profiling shows that most of the time is spent in the arithmetic comparison =/= in okay,
+# which may come from having only boxed integers.
 
-run run_benchmark_time.rb "sh gprolog.sh"                         10 12 "Prolog search (GProlog)"          GProlog
+run run_benchmark_time.rb "sh gprolog.sh"                         10 13 "Prolog search (GProlog)"          Prolog
 
 if test "$USE_MLTON" = "true"
 then

--- a/benchmarks/nqueens/gprolog.sh
+++ b/benchmarks/nqueens/gprolog.sh
@@ -1,0 +1,5 @@
+# Compile native.pl with GNU Prolog's compiler. The generated binary is
+# called "native". It's a Prolog toplevel with the definitions from
+# native.pl compiled in.
+gplc native.pl  || exit 1
+echo "count($1, Count)." | ./native

--- a/benchmarks/nqueens/native.pl
+++ b/benchmarks/nqueens/native.pl
@@ -23,4 +23,6 @@ okay(I, C, [X|XS]) :- C =\= X, (C-X) =\= I, (X-C) =\= I, I1 is I+1, okay(I1, C, 
    number of solutions of Q.
    count(N, Count) holds when Count is the number of
    valid placements of N queens. */
-count(N, Count) :- aggregate_all(count, solve(N, L), Count).
+count(N, Count) :-
+    findall(L, solve(N, L), Solutions),
+    length(Solutions, Count).

--- a/benchmarks/nqueens/prolog.sh
+++ b/benchmarks/nqueens/prolog.sh
@@ -1,1 +1,1 @@
-echo "count($1, Count)." | swipl -f native.pl
+echo "count($1, Count)." | swipl -O -f native.pl

--- a/benchmarks/nqueens/result.data
+++ b/benchmarks/nqueens/result.data
@@ -100,9 +100,11 @@ end-benchmark
 begin-benchmark	Prolog
 script	"sh prolog.sh"
 header	Prolog search (SWI-Prolog)
-point	10	611.0
-point	11	2997.0
-point	12	17616.0
+point	8	104.0
+point	9	152.0
+point	10	375.0
+point	11	1647.0
+point	12	9289.0
 end-benchmark
 
 begin-benchmark	IndirMLton

--- a/benchmarks/nqueens/result.data
+++ b/benchmarks/nqueens/result.data
@@ -99,7 +99,7 @@ end-benchmark
 
 begin-benchmark	Prolog
 script	"sh gprolog.sh"
-header	Prolog search (GProlog)
+header	Prolog search (GNU Prolog)
 point	10	165.0
 point	11	614.0
 point	12	3307.0

--- a/benchmarks/nqueens/result.data
+++ b/benchmarks/nqueens/result.data
@@ -97,7 +97,7 @@ point	12	509.0
 point	13	2810.0
 end-benchmark
 
-begin-benchmark	Prolog
+begin-benchmark	SWIProlog
 script	"sh prolog.sh"
 header	Prolog search (SWI-Prolog)
 point	8	104.0
@@ -105,6 +105,16 @@ point	9	152.0
 point	10	375.0
 point	11	1647.0
 point	12	9289.0
+end-benchmark
+
+begin-benchmark	GProlog
+script	"sh gprolog.sh"
+header	Prolog search (GProlog)
+point	8	73.0
+point	9	81.0
+point	10	165.0
+point	11	614.0
+point	12	3307.0
 end-benchmark
 
 begin-benchmark	IndirMLton

--- a/benchmarks/nqueens/result.data
+++ b/benchmarks/nqueens/result.data
@@ -97,20 +97,13 @@ point	12	509.0
 point	13	2810.0
 end-benchmark
 
-begin-benchmark	SWIProlog
-script	"sh prolog.sh"
-header	Prolog search (SWI-Prolog)
-point	10	375.0
-point	11	1647.0
-point	12	9289.0
-end-benchmark
-
-begin-benchmark	GProlog
+begin-benchmark	Prolog
 script	"sh gprolog.sh"
 header	Prolog search (GProlog)
 point	10	165.0
 point	11	614.0
 point	12	3307.0
+point	13	20401.0
 end-benchmark
 
 begin-benchmark	IndirMLton

--- a/benchmarks/nqueens/result.data
+++ b/benchmarks/nqueens/result.data
@@ -100,8 +100,6 @@ end-benchmark
 begin-benchmark	SWIProlog
 script	"sh prolog.sh"
 header	Prolog search (SWI-Prolog)
-point	8	104.0
-point	9	152.0
 point	10	375.0
 point	11	1647.0
 point	12	9289.0
@@ -110,8 +108,6 @@ end-benchmark
 begin-benchmark	GProlog
 script	"sh gprolog.sh"
 header	Prolog search (GProlog)
-point	8	73.0
-point	9	81.0
 point	10	165.0
 point	11	614.0
 point	12	3307.0


### PR DESCRIPTION
@gergo- kindly volunteered to look at the surprisingly bad numbers for Prolog in our benchmarks. He made a couple tweaks (in particular, moving from SWI Prolog to GNU Prolog) that bring a 5x speedup on my machine. This PR includes his commits, and my own changes to reflect the corresponding numbers in the saved benchmark data. (I have already updated the paper itself.)