### PR TITLE
Docker: split actions (for better caching) and iterate on the OCaml setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,71 @@
 FROM ubuntu:18.04
 
-WORKDIR /thermocont
-ADD . /thermocont
-
 RUN echo 'export USE_MLTON="true"' >> /root/.bashrc
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ruby=1:2.5.1 smlnj=110.79-4 libsmlnj-smlnj=110.79-4 ocaml=4.05.0-10ubuntu1 gprolog=1.4.5-4.1 opam=1.2.2-6 ocamlbuild=0.11.0-3build1 \
-    && apt-get install -y --no-install-recommends m4=1.4.18-1 git=1:2.17.0-1ubuntu1 mlton=20130715-3 vim=2:8.0.1453-1ubuntu1 make=4.1-9.1ubuntu1 \
-    && opam init \
-    && opam install -y ocamlfind.1.8.0 \
-    && opam install -y delimcc.2017.03.02 \
-    && opam remote add multicore https://github.com/ocamllabs/multicore-opam.git \
-    && opam switch 4.06.1+multicore \
-    && opam switch system
-RUN cd /thermocont/benchmarks/nqueens/ocaml \
-    && make \
-    && eval `opam config env ` \
-    && make delimcc \
-    && cd .. \
+## Install the necessary Ubuntu packages
+
+RUN apt-get update
+RUN apt-get install -y --no-install-recommends ruby=1:2.5.1 smlnj=110.79-4 libsmlnj-smlnj=110.79-4 gprolog=1.4.5-4.1
+RUN apt-get install -y --no-install-recommends m4=1.4.18-1 git=1:2.17.0-1ubuntu1 mlton=20130715-3 vim=2:8.0.1453-1ubuntu1 make=4.1-9.1ubuntu1
+RUN apt-get install -y --no-install-recommends aspcud=1:1.9.4-1 opam=1.2.2-6
+# Note: aspcud is an optional dependency of opam (a solver for package installation problems)
+# that makes its dependency-solving more reliable.
+
+
+## Install the OCaml switches
+
+# The OCaml software we use are handled through OPAM, the OCaml-specific package manager,
+# which allows for more flexible control over versions than using Ubuntu packages,
+# and in particular lets us use several different compilers in parallel (the standard
+# implementation, and the 'multicore' experimental variant with effect handlers)
+
+# Install a switch for the standard 4.06.1 compiler, and base packages for it
+RUN opam init --comp 4.06.1
+RUN opam switch 4.06.1 && eval $(opam config env) \
+    && opam install -y ocamlbuild.0.12.0 ocamlfind.1.8.0 delimcc.2017.03.02
+
+# Install the experimental 'multicore' compiler in a 4.06.1+multicore switch
+RUN opam remote add multicore https://github.com/ocamllabs/multicore-opam.git \
+    && opam switch install 4.06.1+multicore
+RUN opam switch 4.06.1+multicore && eval $(opam config env) \
+    && opam install -y ocamlbuild.0.12.0 ocamlfind.1.8.0
+
+
+## Copy the host system's benchmark code
+
+# We intentionally delayed the addition of the working directory upto
+# this point: whenever the directory state changes on the host system,
+# we get a cache miss and every step after this one has to be replayed
+# when rebuilding the Docker image. On the other hand,
+# environment-setting commands above remain cached.
+WORKDIR /thermocont
+ADD benchmarks /thermocont
+
+
+## Build the SML benchmarks
+
+RUN cd /thermocont/nqueens \
     && mlton indirect.sml \
     && mlton replay_zipper.sml \
     && mlton filinski_callcc_derived_universal.sml
+
+## Build the OCaml benchmarks (minus 'effect')
+
+RUN cd /thermocont/nqueens/ocaml \
+    && opam switch 4.06.1 && eval $(opam config env) \
+    && make clean \
+    && make all \
+    && make delimcc
+
+# Note: "ADD benchmarks /thermocont" may copy over the Docker
+# container some build artefacts coming from the host's repository (if
+# it was used for testing and not in a clean state). The 'make clean'
+# run above makes sure we start from a clean state.
+
+## Build the effect-handler OCaml benchmarks
+
+RUN cd /thermocont/nqueens/ocaml \
+    && opam switch 4.06.1+multicore && eval $(opam config env) \
+    && make effect
 
 CMD ["bash"]

--- a/benchmarks/nqueens/ocaml/Makefile
+++ b/benchmarks/nqueens/ocaml/Makefile
@@ -3,6 +3,10 @@ TARGETS=indirect.native \
   replay_zipper.native replay_zipper_nested.native \
   thermometers_generic.native thermometers_optimized.native
 
+DELIMCC_TARGETS=filinski_delimcc.byte filinski_delimcc.native
+
+EFFECT_TARGETS=effect.native
+
 all:
 	@echo "/!\\ the delimcc and effect benchmark are not built by default"
 	@echo "/!\\ as they require external runtime/libraries"
@@ -12,7 +16,7 @@ all:
 delimcc:
 	@echo "/!\\ the delimcc benchmark requires the 'delimcc' library"
 	@ocamlfind query delimcc > /dev/null
-	ocamlbuild -use-ocamlfind -package delimcc filinski_delimcc.byte filinski_delimcc.native
+	ocamlbuild -use-ocamlfind -package delimcc $(DELIMCC_TARGETS)
 	@echo "/!\\ the bytecode version (.byte) may be faster"
 	@echo "/!\\ than the native one (.native), you should test both"
 
@@ -21,7 +25,8 @@ effect:
 	@opam switch show | grep multicore > /dev/null \
 	  || (echo "/!\\ the current switch ($$(opam switch show)) lacks the multicore runtime; see https://github.com/ocamllabs/ocaml-effects-tutorial#setting-up"; \
 	      exit 1)
-	ocamlbuild effect.native
+	ocamlbuild $(EFFECT_TARGETS)
 
 clean:
+	rm $(TARGETS) $(DELIMCC_TARGETS) $(EFFECT_TARGETS)
 	ocamlbuild -classic-display -clean


### PR DESCRIPTION
The new Dockerfile has several RUN actions, which allow for better caching when you change some of the later actions in the file (no need to rebuild the steps of the previous actions). It also fixes the issues with the OCaml benchmarks, at least on my machine.